### PR TITLE
Replace MAX_ARRAY_INDEX with constant Number.MAX_SAFE_INTEGER

### DIFF
--- a/lib/is-array-like.js
+++ b/lib/is-array-like.js
@@ -1,9 +1,7 @@
 const getLength = require('./get-length');
 
-const MAX_ARRAY_INDEX = 2 ** 53 - 1;
-
 module.exports = (collection) => {
 	const length = getLength(collection);
 
-	return typeof length == 'number' && length >= 0 && length <= MAX_ARRAY_INDEX;
+	return typeof length == 'number' && length >= 0 && length <= Number.MAX_SAFE_INTEGER;
 };


### PR DESCRIPTION
It should not be necessary to self calculate MAX_ARRAY_INDEX as this already exists as a default constant by Number: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER

Additional benefit is that this will increase compatibility and fix the issue mentioned for Node 6: https://github.com/jonkemp/package-utils/issues/1